### PR TITLE
Ignore .sln

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs/
 grid/.vs
 
+*.sln
 *.vcxproj.filters
 *.vcxproj.user


### PR DESCRIPTION
Add *.sln to .gitignore. Visual Studio will update the .sln with its own version number which will mean the file will constantly change if 2 contributors use a different Visual Studio version (even if it's simply a different revision).