### PR TITLE
Add a rectangular hex grid implementation

### DIFF
--- a/grid/common/point.h
+++ b/grid/common/point.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace grid::common
+{
+	template<typename Numeric> requires std::is_arithmetic_v<Numeric>
+	struct point_2d
+	{
+		Numeric x;
+		Numeric y;
+	};
+
+	using offset_point = point_2d<std::int32_t>;
+}

--- a/grid/grid.vcxproj
+++ b/grid/grid.vcxproj
@@ -93,8 +93,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="common\point.h" />
     <ClInclude Include="hex_grid\axial_point_fn.h" />
     <ClInclude Include="hex_grid\axial_point.h" />
+    <ClInclude Include="hex_grid\hex_offset_type.h" />
+    <ClInclude Include="hex_grid\hex_point_fn.h" />
+    <ClInclude Include="hex_grid\rect_hex_grid.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>

--- a/grid/hex_grid/hex_offset_type.h
+++ b/grid/hex_grid/hex_offset_type.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace grid::hex
+{
+	/**
+	 * Offset type of a horizontal hex grid.
+	 * 
+	 * The offset type determines whether the even or odd rows are pushed toward the +x direction when
+	 * expressing a point in Cartesian coordinates.
+	 */
+	enum class hex_offset_type
+	{
+		/**
+		 * Push even rows.
+		 */
+		even_offset = 0x0,
+
+		/**
+		 * Push odd rows.
+		 */
+		odd_offset = 0x1
+	};
+}

--- a/grid/hex_grid/hex_point_fn.h
+++ b/grid/hex_grid/hex_point_fn.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstdint>
+
+#include "../common/point.h"
+#include "axial_point.h"
+#include "hex_offset_type.h"
+
+namespace grid::hex
+{
+	/**
+	 * Translate a point from axial coordinates to Cartesian coordinates.
+	 * 
+	 * @param[in] point Point in axial coordinates.
+	 * @return The point in axial coordinates.
+	 */
+	template<hex_offset_type Type>
+	constexpr common::offset_point to_offset_point(axial_point const & point);
+
+	/**
+	 * Translate a point from Cartesian coordinates to axial coordinates.
+	 * 
+	 * @param[in] point Point in Cartesian coordinates.
+	 * @return The point in Cartesian coordinates.
+	 */
+	template<hex_offset_type Type>
+	constexpr axial_point to_axial_point(common::offset_point const & point);
+
+	template<>
+	constexpr common::offset_point to_offset_point<hex_offset_type::even_offset>(axial_point const & point)
+	{
+		std::int32_t x = point.q + (point.r + (point.r & 1)) / 2;
+		std::int32_t y = point.r;
+		return common::offset_point{x, y};
+	}
+
+	template<>
+	constexpr common::offset_point to_offset_point<hex_offset_type::odd_offset>(axial_point const & point)
+	{
+		std::int32_t x = point.q + (point.r - (point.r & 1)) / 2;
+		std::int32_t y = point.r;
+		return common::offset_point{x, y};
+	}
+
+	template<>
+	constexpr axial_point to_axial_point<hex_offset_type::even_offset>(common::offset_point const & point)
+	{
+		std::int32_t q = point.x - (point.y + (point.y & 1)) / 2;
+		std::int32_t r = point.y;
+		return axial_point{q, r};
+	}
+
+	template<>
+	constexpr axial_point to_axial_point<hex_offset_type::odd_offset>(common::offset_point const & point)
+	{
+		std::int32_t q = point.x - (point.y - (point.y & 1)) / 2;
+		std::int32_t r = point.y;
+		return axial_point{q, r};
+	}
+}

--- a/grid/hex_grid/rect_hex_grid.h
+++ b/grid/hex_grid/rect_hex_grid.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "../common/point.h"
+
+namespace grid::hex
+{
+	/**
+	 * Rectagular, horizontal hex grid.
+	 */
+	template<typename Tile>
+	class rect_hex_grid
+	{
+	public:
+		using tile_type = Tile;
+		using const_tile_type = Tile const;
+		using index_type = common::point_2d<std::uint32_t>;
+
+		constexpr explicit rect_hex_grid(std::vector<tile_type> && tiles, std::uint32_t width) :
+			tiles(std::move(tiles))
+		{
+			std::lldiv_t div_result = std::div(this->tiles.size(), width);
+
+			if (!div_result.rem)
+			{
+				throw std::invalid_argument("size of 'tiles' does not divide by 'width' evenly");
+			}
+
+			this->width = width;
+			this->height = div_result.quot;
+		}
+
+		constexpr rect_hex_grid(rect_hex_grid const & other) :
+			tiles(other.tiles), width(other.width), height(other.height)
+		{}
+
+		constexpr rect_hex_grid(rect_hex_grid && other) :
+			tiles(std::move(other.tiles)), width(other.width), height(other.height)
+		{}
+
+		constexpr rect_hex_grid & operator=(rect_hex_grid const & other)
+		{
+			// Depend on std::vector to handle de-allocation and self-assignment.
+			this->tiles = other.tiles;
+			this->width = other.width;
+			this->height = other.height;
+			return *this;
+		}
+
+		constexpr rect_hex_grid & operator=(rect_hex_grid && other)
+		{
+			// Depend on std::vector to handle self-assignment.
+			this->tiles = std::move(other.tiles);
+			this->width = other.width;
+			this->height = other.height;
+			return *this;
+		}
+
+		constexpr const_tile_type & operator()(index_type index) const
+		{
+			return this->tiles[index.x * index.y];
+		}
+
+		constexpr tile_type & operator()(index_type index)
+		{
+			return const_cast<tile_type &>(const_cast<rect_hex_grid<tile_type> const *>(this)->operator()(index));
+		}
+
+		constexpr const_tile_type & get(index_type index) const
+		{
+			if (index.x >= this->width || index.y >= this->height)
+			{
+				throw std::out_of_range("out of bounds");
+			}
+
+			return operator()(index);
+		}
+	
+		constexpr tile_type & get(index_type index)
+		{
+			return const_cast<tile_type &>(const_cast<rect_hex_grid<tile_type> const *>(this)->get(index));
+		}
+
+		constexpr std::uint32_t get_width() const
+		{
+			return this->width;
+		}
+
+		constexpr std::uint32_t get_height() const
+		{
+			return this->height;
+		}
+
+		friend constexpr void swap(rect_hex_grid & lhs, rect_hex_grid & rhs)
+		{
+			using std::swap;
+			swap(lhs.tiles, rhs.tiles);
+			swap(lhs.width, rhs.width);
+			swap(lhs.height, rhs.height);
+		}
+
+	private:
+		std::vector<tile_type> tiles;
+		std::uint32_t width;
+		std::uint32_t height;
+	};
+}

--- a/grid/hex_grid/rect_hex_grid.h
+++ b/grid/hex_grid/rect_hex_grid.h
@@ -11,7 +11,7 @@
 namespace grid::hex
 {
 	/**
-	 * Rectagular, horizontal hex grid.
+	 * Rectagular hex grid which uses a horizontal (i.e. flat-top) orientation.
 	 */
 	template<typename Tile>
 	class rect_hex_grid

--- a/grid/pch.h
+++ b/grid/pch.h
@@ -6,7 +6,11 @@
 
 #pragma once
 
+#include <array>
+#include <cassert>
 #include <cmath>
-#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <utility>
 #include <vector>

--- a/grid/pch.h
+++ b/grid/pch.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <array>
-#include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>


### PR DESCRIPTION
Add a class to represent a rectangular hex grid that uses a horizontal orientation. Internally, the grid is stored in memory using an array to support random access via a non-negative, 2D point.

Add functions to support translating between axial coordinates and Cartesian coordinates.